### PR TITLE
A couple of fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.6
+        language_version: python3
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9

--- a/hootsweet/api.py
+++ b/hootsweet/api.py
@@ -41,7 +41,8 @@ class HootSweet:
         self.client_id, self.client_secret = client_id, client_secret
         token = token or {}
 
-        if refresh_cb is None:
+        self.refresh_cb = refresh_cb
+        if self.refresh_cb is None:
             self.refresh_cb = default_refresh_cb
 
         self.scope = scope or "offline"
@@ -221,7 +222,7 @@ class HootSweet:
         }
         data.update(kwargs)
         json_ = json.dumps(data)
-        return self._make_request(resource, method="POST", json=json_)
+        return self._make_request(resource, method="POST", data=json_)
 
     def get_message(self, message_id: str) -> Dict[str, Any]:
         """Retrieves a message. A message is always associated with a single social
@@ -246,4 +247,4 @@ class HootSweet:
         resource = "messages/%s/approve" % message_id
         data = {"sequenceNumber": sequence_number, "reviewerType": reviewer_type.name}
         json_ = json.dumps(data)
-        return self._make_request(resource, method="POST", json=json_)
+        return self._make_request(resource, method="POST", data=json_)

--- a/hootsweet/api.py
+++ b/hootsweet/api.py
@@ -90,6 +90,10 @@ class HootSweet:
         if self.timeout is not None and "timeout" not in kwargs:
             kwargs["timeout"] = self.timeout
 
+        expires_in = self.token.get("expires_in", 0)
+        if expires_in <= 0:
+            self.refresh_token()
+
         method = kwargs.pop("method", "POST" if "data" in kwargs else "GET")
         response = self.request(method, url, *args, **kwargs)
 


### PR DESCRIPTION
- Ensure that object has a reference to refresh_cb otherwise the code goes into deep recursion due to getattr calls to session and back.

- If expires_in is less than 0, trigger a refresh_token() call.

